### PR TITLE
klte: Don't let builds complete without vendor tree

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -1,5 +1,5 @@
 # Copyright (C) 2014-2016 The CyanogenMod Project
-# Copyright (C) 2017-2020 The LineageOS Project
+# Copyright (C) 2017-2021 The LineageOS Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,4 +34,4 @@ include $(COMMON_PATH)/nfc/pn547/board.mk
 include $(COMMON_PATH)/radio/single/board.mk
 
 # inherit from the proprietary version
--include vendor/samsung/klte/BoardConfigVendor.mk
+include vendor/samsung/klte/BoardConfigVendor.mk

--- a/device.mk
+++ b/device.mk
@@ -1,6 +1,6 @@
 #
 # Copyright (C) 2014 The CyanogenMod Project
-# Copyright (C) 2017-2020 The LineageOS Project
+# Copyright (C) 2017-2021 The LineageOS Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@
 $(call inherit-product, $(SRC_TARGET_DIR)/product/languages_full.mk)
 
 # Get non-open-source specific aspects
-$(call inherit-product-if-exists, vendor/samsung/klte/klte-vendor.mk)
-$(call inherit-product-if-exists, vendor/samsung/klte-common/klte-common-vendor-ril-m.mk)
+$(call inherit-product, vendor/samsung/klte/klte-vendor.mk)
+$(call inherit-product, vendor/samsung/klte-common/klte-common-vendor-ril-m.mk)
 
 # Overlays
 DEVICE_PACKAGE_OVERLAYS += $(LOCAL_PATH)/overlay


### PR DESCRIPTION
* There is zero reason to ever build without blobs. We've even seen
  this situation with official builds from our servers. It's always
  better for a build to fail than it is for it to produce something
  that has no chance at working.

Change-Id: I4968795670c91f691e9ecdc0e4af62e16ba3a93a